### PR TITLE
Relax some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ documentation = "https://docs.rs/fips203"
 categories = ["cryptography", "no-std"]
 repository = "https://github.com/integritychain/fips203"
 keywords = ["FIPS", "203", "lattice", "kem", "ml"]
-rust-version = "1.72"
+rust-version = "1.70"
 
 
 [dependencies]
 zeroize = { version = "1.6.0", features = ["zeroize_derive"] }
 rand_core = { version = "0.6.4", default-features = false }
-sha3 = { version = "0.10.8", default-features = false }
+sha3 = { version = "0.10.2", default-features = false }
 
 
 [features]
@@ -34,7 +34,7 @@ regex = "1.10.2"
 hex = "0.4.3"
 rand_chacha = "0.3.1"
 criterion = "0.5.1"
-flate2 = "1.0.28"
+flate2 = "1.0.27"
 
 [[bench]]
 name = "benchmark"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The Rust [Documentation][docs-link] lives under each **Module** corresponding to
 * This crate is fully functional and corresponds to the first initial public draft of FIPS 203.
 * Constant-time assurances target the source-code level only, and are a work in progress.
 * Note that FIPS 203 places specific requirements on randomness per section 3.3, hence the exposed `RNG`.
-* Requires Rust **1.72** or higher. The minimum supported Rust version may be changed in the future, but
+* Requires Rust **1.70** or higher. The minimum supported Rust version may be changed in the future, but
   it will be done with a minor version bump.
 * All on-by-default features of this library are covered by SemVer.
 * This software is experimental and still under active development -- USE AT YOUR OWN RISK!


### PR DESCRIPTION
With the following dependencies/minimum versions relaxed, both `cargo build` and `cargo test` still succeed:

- MSRV: 1.72 → 1.70

- flate2: 1.0.28 → 1.0.27
- sha3: 0.10.8 → 0.10.2

This allows the crate to be built on debian testing/unstable systems today.

Is there a specific reason you want to require more recent versions of these crates, or of the MSRV?