### PR TITLE
relax regex and zeroize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.8.5"
 regex = "1.10.2"
 hex = "0.4.3"
 rand_chacha = "0.3.1"
-criterion = "0.4.0" # Needed to keep MSRV back at 1.72, newer: "0.5.1"
+criterion = ">=0.4.0, <0.6" # 0.4.0 Needed to keep MSRV back at 1.72, also builds fine with 0.5.1
 flate2 = "1.0.27"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/fips203"
 categories = ["cryptography", "no-std"]
 repository = "https://github.com/integritychain/fips203"
 keywords = ["FIPS", "FIPS203", "lattice", "key", "encapsulation"]
-rust-version = "1.72"
+rust-version = "1.70"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ ml-kem-1024 = []
 
 
 [dependencies]
-zeroize = { version = "1.7.0", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_derive"] }
 rand_core = { version = "0.6.4", default-features = false }
 sha3 = { version = "0.10.2", default-features = false }
 
 
 [dev-dependencies]
 rand = "0.8.5"
-regex = "1.10.3"
+regex = "1.10.2"
 hex = "0.4.3"
 rand_chacha = "0.3.1"
 criterion = "0.4.0" # Needed to keep MSRV back at 1.72, newer: "0.5.1"


### PR DESCRIPTION
These dependencies were bumped without comment or other code change in ff4beaf8ef69f81035fd4ba481926169579ee9dc.  This reverts that part of that commit.  "cargo build" and "cargo test" still both pass.

Neither upstream change was necessary to make the package build or test correctly, from what i can see, and there was no backward-incompatible API change (the versions are semver-compatible).

There is nothing wrong with raising a dependency when it's needed, but raising a dependency above the necessary base version makes it harder to build against older installations.