### PR TITLE
Add minimalist C shared library crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-workspace = { members = [], exclude = ["dudect", "ct_cm4"] }
+workspace = { members = ['ffi'], exclude = ["dudect", "ct_cm4"] }
 
 [package]
 name = "fips203"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fips203-ffi"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "C shared library exposing FIPS 203 (draft): Module-Lattice-Based Key-Encapsulation Mechanism"
+authors = ["Daniel Kahn Gillmor <dkg@fifthhorseman.net>"]
+documentation = "https://docs.rs/fips203"
+categories = ["cryptography"]
+repository = "https://github.com/integritychain/fips203"
+keywords = ["FIPS", "203", "lattice", "kem", "ml"]
+rust-version = "1.70"
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+bench = false
+name = "fips203"
+
+[dependencies.fips203]
+path = ".."
+version = "0.1.2"
+features = [ "default-rng", "ml-kem-512" ]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -19,4 +19,3 @@ name = "fips203"
 [dependencies.fips203]
 path = ".."
 version = "0.1.2"
-features = [ "default-rng", "ml-kem-512" ]

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -1,0 +1,35 @@
+# C Shared Object for ML-KEM
+
+This crate provides a shared object (dynamically-linked library) using standard C FFI ABI that provides a functional implementation of ML-KEM.
+
+The goals of this implementation are:
+
+- simplicity
+- correctness
+- caller deals only with serialized objects
+- no library-specific memory management (caller manages all objects)
+- no internal state held by the library between calls
+- minimal symbol visibility
+- stable API/ABI
+
+security-related goals:
+
+- constant-time operations (needs improvement in underlying Rust code)
+- clean library RAM (objects should be zeroed out of any library-allocated memory before function exit)
+
+non-goals are:
+
+- speed
+- efficiency
+- size
+
+# Outstanding work
+
+- better internal error handling
+- testing!
+- reduce symbol visibility in shared object
+- SONAME (bound to major version?)
+
+# Paths considered but discarded
+
+- Autogenerate stable C headers (e.g. with cbindgen); manually-crafted headers are probably fine, given the simplicity of the API/ABI

--- a/ffi/fips203.h
+++ b/ffi/fips203.h
@@ -1,0 +1,108 @@
+#ifndef __FIPS203_H__
+#define __FIPS203_H__
+/*
+  Minimalist ML-KEM C interface
+  Author: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+
+  Memory allocation and tracking are entirely the job of the caller.
+
+  The shared object backing this interface has no internal state
+  between calls, and should be completely reentrant.
+
+  These functions return true on success, false on error.
+*/
+#include <stdint.h>
+
+typedef uint8_t ml_kem_err;
+
+const ml_kem_err ML_KEM_OK = 0;
+const ml_kem_err ML_KEM_NULL_PTR_ERROR = 1;
+const ml_kem_err ML_KEM_SERIALIZATION_ERROR = 2;
+const ml_kem_err ML_KEM_DESERIALIZATION_ERROR = 3;
+const ml_kem_err ML_KEM_KEYGEN_ERROR = 4;
+const ml_kem_err ML_KEM_ENCAPSULATION_ERROR = 5;
+const ml_kem_err ML_KEM_DECAPSULATION_ERROR = 6;
+
+
+typedef struct ml_kem_shared_secret {
+  uint8_t data[32];
+} ml_kem_shared_secret;
+
+
+typedef struct ml_kem_512_encaps_key {
+  uint8_t data[800];
+} ml_kem_512_encaps_key;
+
+typedef struct ml_kem_512_decaps_key {
+  uint8_t data[1632];
+} ml_kem_512_decaps_key;
+
+typedef struct ml_kem_512_ciphertext {
+  uint8_t data[768];
+} ml_kem_512_ciphertext;
+
+typedef struct ml_kem_768_encaps_key {
+  uint8_t data[1184];
+} ml_kem_768_encaps_key;
+
+typedef struct ml_kem_768_decaps_key {
+  uint8_t data[2400];
+} ml_kem_768_decaps_key;
+
+typedef struct ml_kem_768_ciphertext {
+  uint8_t data[1088];
+} ml_kem_768_ciphertext;
+
+typedef struct ml_kem_1024_encaps_key {
+  uint8_t data[1568];
+} ml_kem_1024_encaps_key;
+
+typedef struct ml_kem_1024_decaps_key {
+  uint8_t data[3168];
+} ml_kem_1024_decaps_key;
+
+typedef struct ml_kem_1024_ciphertext {
+  uint8_t data[1568];
+} ml_kem_1024_ciphertext;
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+ml_kem_err ml_kem_512_keygen(ml_kem_512_encaps_key *encaps_out,
+                             ml_kem_512_decaps_key *decaps_out);
+
+ml_kem_err ml_kem_512_encaps(const ml_kem_512_encaps_key *encaps,
+                             ml_kem_512_ciphertext *ciphertext_out,
+                             ml_kem_shared_secret *shared_secret_out);
+
+ml_kem_err ml_kem_512_decaps(const ml_kem_512_decaps_key *decaps,
+                             const ml_kem_512_ciphertext *ciphertext,
+                             ml_kem_shared_secret *shared_secret_out);
+
+ml_kem_err ml_kem_768_keygen(ml_kem_768_encaps_key *encaps_out,
+                             ml_kem_768_decaps_key *decaps_out);
+
+ml_kem_err ml_kem_768_encaps(const ml_kem_768_encaps_key *encaps,
+                             ml_kem_768_ciphertext *ciphertext_out,
+                             ml_kem_shared_secret *shared_secret_out);
+
+ml_kem_err ml_kem_768_decaps(const ml_kem_768_decaps_key *decaps,
+                             const ml_kem_768_ciphertext *ciphertext,
+                             ml_kem_shared_secret *shared_secret_out);
+
+ml_kem_err ml_kem_1024_keygen(ml_kem_1024_encaps_key *encaps_out,
+                              ml_kem_1024_decaps_key *decaps_out);
+
+ml_kem_err ml_kem_1024_encaps(const ml_kem_1024_encaps_key *encaps,
+                              ml_kem_1024_ciphertext *ciphertext_out,
+                              ml_kem_shared_secret *shared_secret_out);
+
+ml_kem_err ml_kem_1024_decaps(const ml_kem_1024_decaps_key *decaps,
+                              const ml_kem_1024_ciphertext *ciphertext,
+                              ml_kem_shared_secret *shared_secret_out);
+
+#ifdef  __cplusplus
+} // extern "C"
+#endif
+#endif // __FIPS203_H__

--- a/ffi/src/.rustfmt.toml
+++ b/ffi/src/.rustfmt.toml
@@ -1,0 +1,1 @@
+fn_params_layout = "Vertical"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,0 +1,260 @@
+use fips203;
+
+#[repr(C)]
+pub struct ml_kem_shared_secret {
+    data: [u8; fips203::SSK_LEN],
+}
+
+pub const ML_KEM_OK: u8 = 0;
+pub const ML_KEM_NULL_PTR_ERROR: u8 = 1;
+pub const ML_KEM_SERIALIZATION_ERROR: u8 = 2;
+pub const ML_KEM_DESERIALIZATION_ERROR: u8 = 3;
+pub const ML_KEM_KEYGEN_ERROR: u8 = 4;
+pub const ML_KEM_ENCAPSULATION_ERROR: u8 = 5;
+pub const ML_KEM_DECAPSULATION_ERROR: u8 = 6;
+
+// ML-KEM-512
+
+#[repr(C)]
+pub struct ml_kem_512_encaps_key {
+    data: [u8; fips203::ml_kem_512::EK_LEN],
+}
+#[repr(C)]
+pub struct ml_kem_512_decaps_key {
+    data: [u8; fips203::ml_kem_512::DK_LEN],
+}
+#[repr(C)]
+pub struct ml_kem_512_ciphertext {
+    data: [u8; fips203::ml_kem_512::CT_LEN],
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_512_keygen(
+    encaps_out: Option<&mut ml_kem_512_encaps_key>,
+    decaps_out: Option<&mut ml_kem_512_decaps_key>,
+) -> u8 {
+    use fips203::traits::{KeyGen, SerDes};
+
+    let (Some(encaps_out), Some(decaps_out)) = (encaps_out, decaps_out) else  {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok((ek, dk)) = fips203::ml_kem_512::KG::try_keygen_vt() else {
+        return ML_KEM_KEYGEN_ERROR;
+    };
+
+    encaps_out.data = ek.into_bytes();
+    decaps_out.data = dk.into_bytes();
+    return ML_KEM_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_512_encaps(
+    encaps: Option<&ml_kem_512_encaps_key>,
+    ciphertext_out: Option<&mut ml_kem_512_ciphertext>,
+    shared_secret_out: Option<&mut ml_kem_shared_secret>,
+) -> u8 {
+    use fips203::traits::{Encaps, SerDes};
+
+    let (Some(encaps), Some(ciphertext_out), Some(shared_secret_out)) = (encaps, ciphertext_out, shared_secret_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok(ek) = fips203::ml_kem_512::EncapsKey::try_from_bytes(encaps.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok((ssk, ct)) = ek.try_encaps_vt() else {
+        return ML_KEM_ENCAPSULATION_ERROR;
+    };
+
+    shared_secret_out.data = ssk.into_bytes();
+    ciphertext_out.data = ct.into_bytes();
+    return ML_KEM_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_512_decaps(
+    decaps: Option<&ml_kem_512_decaps_key>,
+    ciphertext: Option<&ml_kem_512_ciphertext>,
+    shared_secret_out: Option<&mut ml_kem_shared_secret>,
+) -> u8 {
+    use fips203::traits::{Decaps, SerDes};
+
+    let (Some(decaps), Some(ciphertext), Some(shared_secret_out)) = (decaps, ciphertext, shared_secret_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok(dk) = fips203::ml_kem_512::DecapsKey::try_from_bytes(decaps.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok(ct) = fips203::ml_kem_512::CipherText::try_from_bytes(ciphertext.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok(ssk) = dk.try_decaps_vt(&ct) else {
+        return ML_KEM_DECAPSULATION_ERROR;
+    };
+
+    shared_secret_out.data = ssk.into_bytes();
+    return ML_KEM_OK;
+}
+
+// ML-KEM-768
+
+#[repr(C)]
+pub struct ml_kem_768_encaps_key {
+    data: [u8; fips203::ml_kem_768::EK_LEN],
+}
+#[repr(C)]
+pub struct ml_kem_768_decaps_key {
+    data: [u8; fips203::ml_kem_768::DK_LEN],
+}
+#[repr(C)]
+pub struct ml_kem_768_ciphertext {
+    data: [u8; fips203::ml_kem_768::CT_LEN],
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_768_keygen(
+    encaps_out: Option<&mut ml_kem_768_encaps_key>,
+    decaps_out: Option<&mut ml_kem_768_decaps_key>,
+) -> u8 {
+    use fips203::traits::{KeyGen, SerDes};
+
+    let (Some(encaps_out), Some(decaps_out)) = (encaps_out, decaps_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok((ek, dk)) = fips203::ml_kem_768::KG::try_keygen_vt() else {
+        return ML_KEM_KEYGEN_ERROR;
+    };
+
+    encaps_out.data = ek.into_bytes();
+    decaps_out.data = dk.into_bytes();
+    return ML_KEM_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_768_encaps(
+    encaps: Option<&ml_kem_768_encaps_key>,
+    ciphertext_out: Option<&mut ml_kem_768_ciphertext>,
+    shared_secret_out: Option<&mut ml_kem_shared_secret>,
+) -> u8 {
+    use fips203::traits::{Encaps, SerDes};
+
+    let (Some(encaps), Some(ciphertext_out), Some(shared_secret_out)) = (encaps, ciphertext_out, shared_secret_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok(ek) = fips203::ml_kem_768::EncapsKey::try_from_bytes(encaps.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok((ssk, ct)) = ek.try_encaps_vt() else {
+        return ML_KEM_ENCAPSULATION_ERROR;
+    };
+
+    shared_secret_out.data = ssk.into_bytes();
+    ciphertext_out.data = ct.into_bytes();
+    return ML_KEM_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_768_decaps(
+    decaps: Option<&ml_kem_768_decaps_key>,
+    ciphertext: Option<&ml_kem_768_ciphertext>,
+    shared_secret_out: Option<&mut ml_kem_shared_secret>,
+) -> u8 {
+    use fips203::traits::{Decaps, SerDes};
+
+    let (Some(decaps), Some(ciphertext), Some(shared_secret_out)) = (decaps, ciphertext, shared_secret_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok(dk) = fips203::ml_kem_768::DecapsKey::try_from_bytes(decaps.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok(ct) = fips203::ml_kem_768::CipherText::try_from_bytes(ciphertext.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok(ssk) = dk.try_decaps_vt(&ct) else {
+        return ML_KEM_DECAPSULATION_ERROR;
+    };
+
+    shared_secret_out.data = ssk.into_bytes();
+    return ML_KEM_OK;
+}
+
+// ML-KEM-1024
+
+#[repr(C)]
+pub struct ml_kem_1024_encaps_key {
+    data: [u8; fips203::ml_kem_1024::EK_LEN],
+}
+#[repr(C)]
+pub struct ml_kem_1024_decaps_key {
+    data: [u8; fips203::ml_kem_1024::DK_LEN],
+}
+#[repr(C)]
+pub struct ml_kem_1024_ciphertext {
+    data: [u8; fips203::ml_kem_1024::CT_LEN],
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_1024_keygen(
+    encaps_out: Option<&mut ml_kem_1024_encaps_key>,
+    decaps_out: Option<&mut ml_kem_1024_decaps_key>,
+) -> u8 {
+    use fips203::traits::{KeyGen, SerDes};
+
+    let (Some(encaps_out), Some(decaps_out)) = (encaps_out, decaps_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok((ek, dk)) = fips203::ml_kem_1024::KG::try_keygen_vt() else {
+        return ML_KEM_KEYGEN_ERROR;
+    };
+
+    encaps_out.data = ek.into_bytes();
+    decaps_out.data = dk.into_bytes();
+    return ML_KEM_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_1024_encaps(
+    encaps: Option<&ml_kem_1024_encaps_key>,
+    ciphertext_out: Option<&mut ml_kem_1024_ciphertext>,
+    shared_secret_out: Option<&mut ml_kem_shared_secret>,
+) -> u8 {
+    use fips203::traits::{Encaps, SerDes};
+
+    let (Some(encaps), Some(ciphertext_out), Some(shared_secret_out)) = (encaps, ciphertext_out, shared_secret_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok(ek) = fips203::ml_kem_1024::EncapsKey::try_from_bytes(encaps.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok((ssk, ct)) = ek.try_encaps_vt() else {
+        return ML_KEM_ENCAPSULATION_ERROR;
+    };
+
+    shared_secret_out.data = ssk.into_bytes();
+    ciphertext_out.data = ct.into_bytes();
+    return ML_KEM_OK;
+}
+
+#[no_mangle]
+pub extern "C" fn ml_kem_1024_decaps(
+    decaps: Option<&ml_kem_1024_decaps_key>,
+    ciphertext: Option<&ml_kem_1024_ciphertext>,
+    shared_secret_out: Option<&mut ml_kem_shared_secret>,
+) -> u8 {
+    use fips203::traits::{Decaps, SerDes};
+
+    let (Some(decaps), Some(ciphertext), Some(shared_secret_out)) = (decaps, ciphertext, shared_secret_out) else {
+        return ML_KEM_NULL_PTR_ERROR;
+    };
+    let Ok(dk) = fips203::ml_kem_1024::DecapsKey::try_from_bytes(decaps.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok(ct) = fips203::ml_kem_1024::CipherText::try_from_bytes(ciphertext.data) else {
+        return ML_KEM_DESERIALIZATION_ERROR;
+    };
+    let Ok(ssk) = dk.try_decaps_vt(&ct) else {
+        return ML_KEM_DECAPSULATION_ERROR;
+    };
+
+    shared_secret_out.data = ssk.into_bytes();
+    return ML_KEM_OK;
+}

--- a/ffi/tests/Makefile
+++ b/ffi/tests/Makefile
@@ -1,0 +1,19 @@
+SO_LOCATION = ../../target/debug
+SIZES = 512 768 1024
+FRAMES = encaps_key decaps_key ciphertext encaps decaps keygen
+
+BASELINES=$(foreach sz, $(SIZES), baseline-$(sz))
+CHECKS=$(foreach sz, $(SIZES), runtest-$(sz))
+
+check: $(CHECKS)
+
+runtest-%: baseline-%
+	LD_LIBRARY_PATH=$(SO_LOCATION) ./$<
+
+baseline-%: baseline.c ../fips203.h
+	$(CC) -o $@ -g -D MLKEM_size=$* $(foreach v, $(FRAMES),-D MLKEM_$(v)=ml_kem_$*_$(v)) -Werror -Wall -pedantic -L $(SO_LOCATION) $< -Wall -lfips203
+
+clean:
+	rm -f $(BASELINES)
+
+.PHONY: clean check

--- a/ffi/tests/baseline.c
+++ b/ffi/tests/baseline.c
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include "../fips203.h"
+
+int main(int argc, const char **argv) {
+  MLKEM_encaps_key encaps;
+  MLKEM_decaps_key decaps;
+  MLKEM_ciphertext ct;
+  ml_kem_shared_secret ssk_a;
+  ml_kem_shared_secret ssk_b;
+  ml_kem_err err;
+  MLKEM_encaps_key encaps_weird;
+  MLKEM_decaps_key decaps_weird;
+
+  if (MLKEM_keygen (&encaps, &decaps))
+      return 1;
+
+  printf("Encaps (%d): ", MLKEM_size);
+  for (int n = 0; n < sizeof(encaps.data); n++)
+    printf ("%02x ", encaps.data[n]);
+  printf("\n");
+  
+  printf("Decaps (%d): ", MLKEM_size);
+  for (int n = 0; n < sizeof(decaps.data); n++)
+    printf ("%02x ", decaps.data[n]);
+  printf("\n");
+
+  if (MLKEM_encaps (&encaps, &ct, &ssk_a))
+    return 2;
+
+  printf("Ciphertext (%d): ", MLKEM_size);
+  for (int n = 0; n < sizeof(ct.data); n++)
+    printf ("%02x ", ct.data[n]);
+  printf("\n");
+
+  printf("Shared Secret A: ");
+  for (int n = 0; n < sizeof(ssk_a.data); n++)
+    printf ("%02x ", ssk_a.data[n]);
+  printf("\n");
+
+  if (MLKEM_decaps (&decaps, &ct, &ssk_b))
+    return 3;
+
+  printf("Shared Secret B: ");
+  for (int n = 0; n < sizeof(ssk_b.data); n++)
+    printf ("%02x ", ssk_b.data[n]);
+  printf("\n");
+
+  if (! MLKEM_keygen (&encaps, NULL)) {
+    fprintf (stderr, "keygen should have failed with NULL decaps\n");
+    return 1;
+  }
+  if (! MLKEM_keygen (NULL, &decaps)) {
+    fprintf (stderr, "keygen should have failed with NULL encaps\n");
+    return 1;
+  }
+  if (! MLKEM_keygen (NULL, NULL)) {
+    fprintf (stderr, "keygen should have failed with NULL encaps and decaps\n");
+    return 1;
+  }
+
+
+  if (! MLKEM_encaps (&encaps, &ct, NULL)) {
+    fprintf (stderr, "encaps should have failed with NULL shared_secret_out\n");
+    return 1;
+  }
+  if (! MLKEM_encaps (&encaps, NULL, &ssk_a)) {
+    fprintf (stderr, "encaps should have failed with NULL ciphertext_out\n");
+    return 1;
+  }
+  if (! MLKEM_encaps (NULL, &ct, &ssk_a)) {
+    fprintf (stderr, "encaps should have failed with NULL encaps_key\n");
+    return 1;
+  }
+  if (! MLKEM_encaps (NULL, NULL, NULL)) {
+    fprintf (stderr, "encaps should have failed with NULL arguments\n");
+    return 1;
+  }
+
+
+  if (! MLKEM_decaps (&decaps, &ct, NULL)) {
+    fprintf (stderr, "decaps should have failed with NULL shared_secret_out\n");
+    return 1;
+  }
+  if (! MLKEM_decaps (&decaps, NULL, &ssk_b)) {
+    fprintf (stderr, "decaps should have failed with NULL ciphertext\n");
+    return 1;
+  }
+  if (! MLKEM_decaps (NULL, &ct, &ssk_b)) {
+    fprintf (stderr, "decaps should have failed with NULL decaps_key\n");
+    return 1;
+  }
+  if (! MLKEM_decaps (NULL, NULL, NULL)) {
+    fprintf (stderr, "decaps should have failed with NULL arguments\n");
+    return 1;
+  }
+
+  for (int i = 0; i < sizeof(encaps_weird.data); i++)
+    encaps_weird.data[i] = 0xff;
+  err = MLKEM_encaps (&encaps_weird, &ct, &ssk_a);
+  if (err != ML_KEM_DESERIALIZATION_ERROR) {
+    fprintf (stderr, "encaps against an encaps_key of all 0xff octets should have failed with deserialization error, got %d\n", err);
+    return 1;
+  }
+
+  for (int i = 0; i < sizeof(decaps_weird.data); i++)
+    decaps_weird.data[i] = 0xff;
+  err = MLKEM_decaps (&decaps_weird, &ct, &ssk_a);
+  if (err != ML_KEM_DECAPSULATION_ERROR) {
+    fprintf (stderr, "decaps against a tampered decaps_key should have failed with decapsulation error, got %d\n", err);
+    return 1;
+  } 
+  
+  return 0;
+}


### PR DESCRIPTION
This shared object provides a C API/ABI for a dynamically linked library.

It is deliberately minimal, and can be linked against with the included fips203.h, and subsequently linked against the .so built by this cdylib.

The caller handles only serialized forms of the underlying cryptographic objects, and is responsible for all memory allocation/destruction.

A more sophisticated library interface seems possible, but this one is clean and can be easily bound to other programming languages that already have the ability to wrap a C FFI.

This includes a simple test, which should be able to be run with:

    (cd tests && make)

On any system that has GNU make and a C compiler available.

I don't know how to integrate such a test into cargo's test suite, though.