### PR TITLE
Relax flate2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ regex = "1.10.2"
 hex = "0.4.3"
 rand_chacha = "0.3.1"
 criterion = "0.4.0"
-flate2 = "1.0.28"
+flate2 = "1.0.27"
 hex-literal = "0.4.1"
 
 


### PR DESCRIPTION
This dependency relaxation was done originally in
4cc8a3cb9983ee7bef63fd1ce9547bd538c3e6af but then appears to have been reverted without explanation in
797fd6707766b84e11ae217be6c5bb8f43d210bd

Tests all still pass even with flate2 1.0.27

This helps for building on systems like debian unstable, which currently does not have flate2 1.0.28.