### PR TITLE
Set FFI SONAME to fips203-ffi crate major version

### DIFF
--- a/ffi/README.md
+++ b/ffi/README.md
@@ -28,7 +28,6 @@ non-goals are:
 - better internal error handling
 - testing!
 - reduce symbol visibility in shared object
-- SONAME (bound to major version?)
 
 # Paths considered but discarded
 

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libfips203.so.{}",
+             std::env::var("CARGO_PKG_VERSION_MAJOR").unwrap());
+}

--- a/ffi/tests/Makefile
+++ b/ffi/tests/Makefile
@@ -1,13 +1,18 @@
 SO_LOCATION = ../../target/debug
 SIZES = 512 768 1024
 FRAMES = encaps_key decaps_key ciphertext encaps decaps keygen
+# should derive SONAME somehow, e.g. from CARGO_PKG_VERSION_MAJOR
+SONAME = 0
 
 BASELINES=$(foreach sz, $(SIZES), baseline-$(sz))
 CHECKS=$(foreach sz, $(SIZES), runtest-$(sz))
 
 check: $(CHECKS)
 
-runtest-%: baseline-%
+$(SO_LOCATION)/libfips203.so.$(SONAME): $(SO_LOCATION)/libfips203.so
+	ln -s $< $@
+
+runtest-%: baseline-% $(SO_LOCATION)/libfips203.so.$(SONAME)
 	LD_LIBRARY_PATH=$(SO_LOCATION) ./$<
 
 baseline-%: baseline.c ../fips203.h


### PR DESCRIPTION
SONAME represents the backward-compatible API for a C shared object.

Using the major version number for this seems like a reasonable first pass, given the semver semantics.

---

Note that it would be better if Cargo handled this automatically itself: https://github.com/rust-lang/cargo/issues/5045  But in the meantime, it isn't unreasonable to just drop it in explicitly.