### PR TITLE
ffi: Adjust tests to be able to test a system-installed library

### DIFF
--- a/ffi/tests/Makefile
+++ b/ffi/tests/Makefile
@@ -1,24 +1,42 @@
-SO_LOCATION = ../../target/debug
+#!/usr/bin/make -f
+
+# Usage: (cargo build && cd tests && make)
+
+# If the library and its development headers are installed system-wide,
+# run the tests with:
+#
+#  (cd tests && make AS_INSTALLED=true)
+
 SIZES = 512 768 1024
 FRAMES = encaps_key decaps_key ciphertext encaps decaps keygen
 # should derive SONAME somehow, e.g. from CARGO_PKG_VERSION_MAJOR
 SONAME = 0
+
+all: check
+
+# adjustments for testing the local debug build:
+ifneq ($(AS_INSTALLED),true)
+SO_LOCATION = ../../target/debug
+$(SO_LOCATION)/libfips203.so.$(SONAME): $(SO_LOCATION)/libfips203.so
+	ln -s $< $@
+EXTRA_CLEANUP=$(SO_LOCATION)/libfips203.so.$(SONAME)
+COMPILE_FLAGS = -L $(SO_LOCATION) -I ..
+RUN_PREFIX = LD_LIBRARY_PATH=$(SO_LOCATION)
+runtest-%: $(SO_LOCATION)/libfips203.so.$(SONAME)
+endif
 
 BASELINES=$(foreach sz, $(SIZES), baseline-$(sz))
 CHECKS=$(foreach sz, $(SIZES), runtest-$(sz))
 
 check: $(CHECKS)
 
-$(SO_LOCATION)/libfips203.so.$(SONAME): $(SO_LOCATION)/libfips203.so
-	ln -s $< $@
-
-runtest-%: baseline-% $(SO_LOCATION)/libfips203.so.$(SONAME)
-	LD_LIBRARY_PATH=$(SO_LOCATION) ./$<
+runtest-%: baseline-%
+	$(RUN_PREFIX) ./$<
 
 baseline-%: baseline.c ../fips203.h
-	$(CC) -o $@ -g -D MLKEM_size=$* $(foreach v, $(FRAMES),-D MLKEM_$(v)=ml_kem_$*_$(v)) -Werror -Wall -pedantic -L $(SO_LOCATION) $< -Wall -lfips203
+	$(CC) -o $@ -g -D MLKEM_size=$* $(foreach v, $(FRAMES),-D MLKEM_$(v)=ml_kem_$*_$(v)) -Werror -Wall -pedantic $< -Wall $(COMPILE_FLAGS) -lfips203
 
 clean:
-	rm -f $(BASELINES)
+	rm -f $(BASELINES) $(EXTRA_CLEANUP)
 
-.PHONY: clean check
+.PHONY: clean check all

--- a/ffi/tests/baseline.c
+++ b/ffi/tests/baseline.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include "../fips203.h"
+#include <fips203.h>
 
 int main(int argc, const char **argv) {
   MLKEM_encaps_key encaps;


### PR DESCRIPTION
This lets me re-use the FFI test suite on GNU/Linux without rust or cargo installed, while still letting test suite work during development.