### PR TITLE
fips203.h: Correct the framing comment

### DIFF
--- a/ffi/fips203.h
+++ b/ffi/fips203.h
@@ -9,7 +9,8 @@
   The shared object backing this interface has no internal state
   between calls, and should be completely reentrant.
 
-  These functions return true on success, false on error.
+  These functions return 0 (ML_KEM_OK) on success, or a more specific
+  non-zero octet on error.
 */
 #include <stdint.h>
 


### PR DESCRIPTION
When developing, i experimented with a couple different APIs, and it looks like i left a comment in place that doesn't match the API i landed on. This change aligns the comment with the API as it exists.