### PR TITLE
Clean up python packaging

### DIFF
--- a/ffi/python/README.md
+++ b/ffi/python/README.md
@@ -1,0 +1,80 @@
+# `fips203` Python module
+
+This Python module provides an implementation of FIPS 203, the
+Module-Lattice-based Key Encapsulation Mechanism Standard.
+
+The underlying mechanism is intended to offer "post-quantum"
+asymmetric encryption and decryption.
+
+## Example
+
+The following example shows using the standard ML-KEM algorithm to
+produce identical 32-byte shared secrets:
+
+```
+from fips203 import ML_KEM_512
+
+(encapsulation_key, decapsulation_key) = ML_KEM_512.keygen()
+(ciphertext, shared_secret_1) = encapsulation_key.encaps()
+shared_secret_2 = decapsulation_key.decaps(ciphertext)
+assert(shared_secret_1 == shared_secret_2)
+```
+
+Encapsulation keys, decapsulation keys, and ciphertexts can all be
+serialized by accessing them as `bytes`, and deserialized by
+initializing them with the appropriate size bytes object.
+
+A serialization example:
+
+```
+from fips203 import ML_KEM_768
+
+(ek,dk) = ML_KEM_768.keygen()
+with open('encapskey.bin', 'wb') as f:
+    f.write(bytes(ek))
+with open('decapskey.bin', 'wb') as f:
+    f.write(bytes(dk))
+```
+
+A deserialization example, followed by use:
+
+```
+import fips203
+
+with open('encapskey.bin', 'b') as f:
+    ekdata = f.read()
+
+ek = fips203.EncapsulationKey(ekdata)
+(ct, ss) = ek.Encaps()
+```
+
+The expected sizes (in bytes) of the different objects in each
+parameter set can be accessed with `EK_SIZE`, `DK_SIZE`, `CT_SIZE`,
+and `SS_SIZE`:
+
+```
+from fips203 import ML_KEM_768
+
+print(f"ML-KEM-768 Ciphertext size (in bytes) is {ML_KEM_768.CT_SIZE}")
+```
+
+## Implementation Notes
+
+This is a wrapper around libfips203, built from the Rust fips203-ffi crate.
+
+If that library is not installed in the expected path for libraries on
+your system, any attempt to use this module will fail.
+
+This module should have reasonable type annotations and docstrings for
+the public interface.  If you discover a problem with type
+annotations, or see a way that this kind of documentation could be
+improved, please report it!
+
+## See Also
+
+- https://doi.org/10.6028/NIST.FIPS.203.ipd
+- https://github.com/integritychain/fips203
+
+## Bug Reporting
+
+Please report issues at https://github.com/integritychain/fips203/issues

--- a/ffi/python/fips203.py
+++ b/ffi/python/fips203.py
@@ -3,6 +3,9 @@
 This Python module provides an implementation of FIPS 203, the
 Module-Lattice-based Key Encapsulation Mechanism Standard.
 
+The underlying mechanism is intended to offer "post-quantum"
+asymmetric encryption and decryption.
+
 ## Example
 
 The following example shows using the standard ML-KEM algorithm to
@@ -62,14 +65,23 @@ This is a wrapper around libfips203, built from the Rust fips203-ffi crate.
 If that library is not installed in the expected path for libraries on
 your system, any attempt to use this module will fail.
 
+This module should have reasonable type annotations and docstrings for
+the public interface.  If you discover a problem with type
+annotations, or see a way that this kind of documentation could be
+improved, please report it!
+
 ## See Also
 
 - https://doi.org/10.6028/NIST.FIPS.203.ipd
 - https://github.com/integritychain/fips203
 
+## Bug Reporting
+
+Please report issues at https://github.com/integritychain/fips203/issues
 '''
 
-__version__ = '0.1'
+'''__version__ should track package.version from  ../Cargo.toml'''
+__version__ = '0.2.1'
 __author__ = 'Daniel Kahn Gillmor <dkg@fifthhorseman.net>'
 __all__ = [
     'ML_KEM_512',

--- a/ffi/python/pyproject.toml
+++ b/ffi/python/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fips203"
+dynamic = ["version"]
+description = "ML-KEM (FIPS203) -- asymmetric, quantum-secure encryption (Initial Public Draft)"
+authors = [{name = "Daniel Kahn Gillmor", email = "dkg@fifthhorseman.net"}]
+keywords = [
+ "cryptography",
+ "encryption",
+ "FIPS",
+ "FIPS203",
+ "KEM",
+ "lattice",
+ "module-lattice",
+ "post-quantum",
+]
+# README.md duplicates the module docstring.
+# I do not know how to keep them automatically in sync
+readme = "README.md"
+# only dependencies are having the libfips203 shared object available
+# everything else is from the stdlib
+dependencies = []
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Telecommunications Industry",
+  "Intended Audience :: Information Technology",
+  "Topic :: Security :: Cryptography",
+  "License :: OSI Approved :: MIT License",
+  # Apache 2.0 license is not in the list of known classifiers
+  # So the dual licensing of this module is not adequately represented
+  #  "License :: OSI Approved :: Apache 2.0 License",
+  "License :: DFSG approved",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+
+[project.urls]
+Homepage = "https://github.com/integritychain/fips203/tree/main/ffi/python"
+Repository = "https://github.com/integritychain/fips203.git"
+Issues = "https://github.com/integritychain/fips203/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "fips203.__version__"}


### PR DESCRIPTION
This shuffling of metadata about the Python module will help submit the package to PyPI.

Note that README.md contains the same content as the module-level docstring.  I couldn't see a way to easily derive one from the other so for the moment they should be kept manually in sync.

Dynamic metadata documentation only permits me to identify a file or set of files, but not to extract an attr:

    https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata

I also couldn't find a way to cleanly/explicitly represent the dual-licensing in the Python classifiers, because Apache 2.0 is not listed:

    https://pypi.org/classifiers/

Nonetheless, this is better than no documentation.