### PR TITLE
Generate a minimalist pkg-config file for use with the library

### DIFF
--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -1,4 +1,27 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
 fn main() {
     println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libfips203.so.{}",
              std::env::var("CARGO_PKG_VERSION_MAJOR").unwrap());
+
+    // Write minimal pkg-config file:
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let libname = "fips203";
+    let mut desc = std::env::var("CARGO_PKG_DESCRIPTION").unwrap();
+    // strip beginning text:
+    let begin_text = "C shared library exposing ";
+    assert!(desc.starts_with(begin_text));
+    desc.replace_range(..begin_text.len(), "");
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    let url = std::env::var("CARGO_PKG_REPOSITORY").unwrap();
+    let pc_dest_path = Path::new(&out_dir).join(format!("{libname}.pc"));
+
+    fs::write(pc_dest_path, format!("Name: {libname}
+Description: {desc}
+Version: {version}
+URL: {url}
+Libs: -l{libname}
+")).unwrap()
 }


### PR DESCRIPTION
Providing pkg-config integration even for very straightforward/trivial components can useful:

 - it's the same uniform interface

 - it makes build-time detection trivial from most build systems

 - it will hide implementation details in case you need to depend on something else in the future (either via the .h or the code)

 - you can specify required build flags that the users need, etc

We don't need to worry about anything fancy right now, but generating the pkg-config file and shipping it for the future will make it easier to add things in the future.