### PR TITLE
python: track version number

### DIFF
--- a/ffi/python/fips203.py
+++ b/ffi/python/fips203.py
@@ -81,7 +81,7 @@ Please report issues at https://github.com/integritychain/fips203/issues
 '''
 
 '''__version__ should track package.version from  ../Cargo.toml'''
-__version__ = '0.2.1'
+__version__ = '0.4.0'
 __author__ = 'Daniel Kahn Gillmor <dkg@fifthhorseman.net>'
 __all__ = [
     'ML_KEM_512',


### PR DESCRIPTION
I think this was just an oversight in the move from 0.2.1 to 0.4.0.

I aim to exposing the seed interface in the ffi and in the python module, but i figure we should start from an aligned version.